### PR TITLE
Link to bottlecapai.com in README.md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![logo](img/logo.png)
 Hey there! Are you interested in LLMs? Do you like experimenting with neural networks, implementing different ideas and testing them out? Would you like to do that for a living? Then you're in to the right place!
-This is an official open test for (not only) people interested in joining [BottleCapAI](!www.bottlecapai.com).
+This is an official open test for (not only) people interested in joining [BottleCapAI](https://www.bottlecapai.com).
 
 This project is a fork of [Modded-NanoGPT](https://github.com/KellerJordan/modded-nanogpt) :heart:, rewritten with minimal changes to run on a single GPU (e.g. RTX 3090/4090)
 


### PR DESCRIPTION
The link went to https://github.com/BottleCapAI/NoCap-Test/blob/master/!www.bottlecapai.com instead of https://www.bottlecapai.com/