### PR TITLE
Fix logged train_loss double-division with gradient accumulation

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -555,10 +555,6 @@ if __name__ == "__main__":
             # backward pass
             loss.backward()
 
-        train_loss /= (
-            args.grad_accumulation_steps
-        )  # average the loss over all micro steps
-
         # determine and set the learning rate for this iteration
         lr = get_lr(step)
         for param_group in optimizer.param_groups:


### PR DESCRIPTION
The loss was being divided by grad_accumulation_steps twice:                                                                                                                                                             
1. During accumulation: loss = loss / args.grad_accumulation_steps                                                                                                                                                       
2. After the loop (removed): train_loss /= args.grad_accumulation_steps                                                                                                                                                  
                                                                                                                                                                                                                       
This caused logged training loss to appear ~32x smaller than actual values (e.g., 0.34 instead of 10.9), while validation loss remained correct. The bug only affected stdout/logfile output, not training or wandb      
metrics.                                                                                                                                                                                                                 
                                                                                                                                                                                                                       
Note: wandb/run-20250410_203158-64s1zc1w/files/output.log contains buggy loss values and should be regenerated on a 4090.