### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The dataset is pre-tokenized so that you don't have to do that yourself (saves t
 To run the baseline, run the following commands.
 ```bash
 git clone git@github.com:BottleCapAI/NoCap-Test && cd NoCap-Test/
-pip install -r requirements.txt
+pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/nightly/cu128
 
 # you can skip this if you don't want to use W&B, in which case you should remove the --log_wandb argument from run.sh
 wandb login

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The dataset is pre-tokenized so that you don't have to do that yourself (saves t
 
 To run the baseline, run the following commands.
 ```bash
-git clone git@github.com:BottleCapAI/NoCap-Test && cd NoCap-Test/
+git clone https://github.com/BottleCapAI/NoCap-Test && cd NoCap-Test/
 pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/nightly/cu128
 
 # you can skip this if you don't want to use W&B, in which case you should remove the --log_wandb argument from run.sh

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The dataset is pre-tokenized so that you don't have to do that yourself (saves t
 
 To run the baseline, run the following commands.
 ```bash
-git clone https://github.com/BottleCapAI/modded-nanogpt && cd modded-nanogpt
+git clone git@github.com:BottleCapAI/NoCap-Test && cd NoCap-Test/
 pip install -r requirements.txt
 
 # you can skip this if you don't want to use W&B, in which case you should remove the --log_wandb argument from run.sh


### PR DESCRIPTION
### Summary
Updates the "Running the baseline" section with correct repository URL and pip install command.

### Changes
- Update git clone URL from `modded-nanogpt` to `NoCap-Test` repository
- Add PyTorch nightly index URL (`--extra-index-url https://download.pytorch.org/whl/nightly/cu128`) to pip install command for CUDA 12.8 support